### PR TITLE
Refactor Random Algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BUILD_DIR = .build
 BUILD_DIR_DEBUG = .debug
 
 NLHOMANN_JSON_HEADERS_PATH = ${BUILD_DIR}/_deps/json-src/include
+PCG_HEADERS_PATH = ${BUILD_DIR}/_deps/pcg-src/include
 
 clean:
 	@rm -rf ${BUILD_DIR} ${BUILD_DIR_DEBUG}
@@ -68,12 +69,14 @@ r-clean:
 		${R_PACKAGE_DIR}/src/.build \
 		${R_PACKAGE_DIR}/inst/lib \
 		${R_PACKAGE_DIR}/inst/include/nlohmann \
+		${R_PACKAGE_DIR}/inst/include/pcg_* \
 		PPTree_${R_PACKAGE_VERSION}.tar.gzm \
 		PPTree.Rcheck
 
 r-prepare: r-clean
 	@mkdir -p ${R_PACKAGE_DIR}/src/core && cp -r core/* ${R_PACKAGE_DIR}/src/core
 	@cp -r ${NLHOMANN_JSON_HEADERS_PATH}/* ${R_PACKAGE_DIR}/inst/include
+	@cp -r ${PCG_HEADERS_PATH}/* ${R_PACKAGE_DIR}/inst/include
 
 r-document:
 	@make r-prepare

--- a/bindings/R/PPTree/src/Makevars.in
+++ b/bindings/R/PPTree/src/Makevars.in
@@ -10,8 +10,9 @@ all: pptree $(SHLIB)
 
 DEV_PACKAGE_DIR = bindings/R/PPTree
 DEV_NLHOHMMAN_DIR = $(BUILD_DIR)/_deps/json-src/include
+DEV_PCG_DIR = $(BUILD_DIR)/_deps/pcg-src/include
 DEV_CORE_DIR = core
- 
+
 pptree:
 	@if [ -f .core ]; then \
 		cd ../../../..;\
@@ -19,6 +20,7 @@ pptree:
 		mkdir -p $(BUILD_DIR); \
 		make build-no-test; \
 		cp -r $(DEV_NLHOHMMAN_DIR)/* $(DEV_PACKAGE_DIR)/inst/include; \
+		cp -r $(DEV_PCG_DIR)/* $(DEV_PACKAGE_DIR)/inst/include; \
 		mkdir -p ${DEV_PACKAGE_DIR}/src/core && cp -r core/* ${DEV_PACKAGE_DIR}/src/core; \
 	fi
 

--- a/bindings/R/PPTree/src/Makevars.win
+++ b/bindings/R/PPTree/src/Makevars.win
@@ -7,6 +7,11 @@ PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
 BUILD_DIR = .build
 
 all: pptree $(SHLIB)
+
+DEV_PACKAGE_DIR = bindings/R/PPTree
+DEV_NLHOHMMAN_DIR = $(BUILD_DIR)/_deps/json-src/include
+DEV_PCG_DIR = $(BUILD_DIR)/_deps/pcg-src/include
+DEV_CORE_DIR = core
  
 pptree:
 	@if [ -f .core ]; then \
@@ -15,6 +20,7 @@ pptree:
 		mkdir -p $(BUILD_DIR); \
 		make build-no-test; \
 		cp -r $(DEV_NLHOHMMAN_DIR)/* $(DEV_PACKAGE_DIR)/inst/include; \
+		cp -r $(DEV_PCG_DIR)/* $(DEV_PACKAGE_DIR)/inst/include; \
 		mkdir -p ${DEV_PACKAGE_DIR}/src/core && cp -r core/* ${DEV_PACKAGE_DIR}/src/core; \
 	fi
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -62,6 +62,19 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(json)
 
+# PCG Random Number Generation
+FetchContent_Declare(
+  pcg
+  GIT_REPOSITORY https://github.com/imneme/pcg-cpp.git
+  GIT_TAG v0.98.1
+)
+FetchContent_GetProperties(pcg)
+if(NOT pcg_POPULATED)
+  FetchContent_Populate(pcg)
+  add_library(pcg INTERFACE)
+  target_include_directories(pcg INTERFACE ${pcg_SOURCE_DIR}/include)
+endif()
+
 # Collect all .cpp files from the specified directories
 file(GLOB_RECURSE ALL_CPP_FILES ./**/*.cpp)
 
@@ -82,7 +95,8 @@ target_include_directories(pptree
 
 target_link_libraries(pptree
   Eigen3::Eigen
-  nlohmann_json::nlohmann_json)
+  nlohmann_json::nlohmann_json
+  pcg)
 
 if(OpenMP_FOUND)
   target_link_libraries(pptree OpenMP::OpenMP_CXX)
@@ -99,7 +113,8 @@ if(TEST_SOURCES AND NOT PPTREE_SKIP_TESTS)
 
   target_link_libraries(pptree_singlethreaded
     Eigen3::Eigen
-    nlohmann_json::nlohmann_json)
+    nlohmann_json::nlohmann_json
+    pcg)
 
   # Google Test
   FetchContent_Declare(

--- a/core/src/BootstrapTree.test.cpp
+++ b/core/src/BootstrapTree.test.cpp
@@ -1422,8 +1422,8 @@ TEST(BootstrapTree, VariableImportancePermutationLDAMultivariateThreeGroups) {
 
   DataColumn<float> expected(5);
   expected <<
-    0.33333,
     0.44444,
+    0.27777,
     0.00000,
     0.00000,
     0.00000;

--- a/core/src/Forest.test.cpp
+++ b/core/src/Forest.test.cpp
@@ -101,75 +101,62 @@ TEST(Forest, TrainLDAAllVariablesMultivariateThreeGroups) {
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.3959386339593606, -0.908269881092349, -0.05734470673819268, 0.08786184419030313, -0.0852660670107132 }),
-        -1.7110096455357062,
+        as_projector({ 0.9580563306808472, -0.1769358515739441, 0.006788997910916805, 0.10231061279773712, -0.2007693350315094 }),
+        3.9684371948242188,
         std::make_unique<Condition<float, int> >(
-          as_projector({ -1.803617104793913e-15, 1.0, -0.0, 0.0, 0.0 }),
-          6.49999999999999,
-          std::make_unique<Response<float, int> >(1),
-          std::make_unique<Response<float, int> >(2)
+          as_projector({ 0.037195101380348206, 0.9892118573188782, -0.038433052599430084, 0.03852792829275131, 0.13082443177700043 }),
+          2.7188374996185303,
+          std::make_unique<Response<float, int> >(0),
+          std::make_unique<Response<float, int> >(1)
           ),
-        std::make_unique<Response<float, int> >(0)
-        ),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
+        std::make_unique<Response<float, int> >(2)
+        ))
     );
 
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.9429063113601566, -0.1791114759384774, -0.1577467223900484, 0.07803343725612998, -0.21880018608199273 }),
-        3.745534637999798,
+        as_projector({ 0.9805806875228882, -0.19611600041389465, -7.279736990994934e-08, 1.1245992226349699e-07, -9.458754135494019e-08 }),
+        4.118439674377441,
         std::make_unique<Condition<float, int> >(
-          as_projector({ 0.09705833399783349, 0.9801862846848319, -0.027094022564766305, -0.005144434664196154, 0.17045226854036435 }),
-          2.8344748952402568,
+          as_projector({ 0.0, 1.0, -1.9481838364754367e-08, 1.0491407920198981e-07, -4.4338150928524556e-08 }),
+          2.5,
           std::make_unique<Response<float, int> >(0),
           std::make_unique<Response<float, int> >(1)
           ),
         std::make_unique<Response<float, int> >(2)
-        ),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
+        ))
     );
-
 
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.9541878806121409, -0.1693811442451475, -0.11681578122561698, 0.07761527693154766, -0.20289272660843075 }),
-        3.8815126994794134,
+        as_projector({ 0.9729747772216797, -0.1960887610912323, -0.038586050271987915, 0.0533757247030735, -0.10262320935726166 }),
+        3.9661753177642822,
         std::make_unique<Condition<float, int> >(
-          as_projector({ 0.07964113289220642, 0.9872406081485949, -0.019516630829984314, 0.04771950247256534, 0.1278875356665199 }),
-          2.8098223049798854,
+          as_projector({ 0.2779413163661957, 0.9268009662628174, -0.11087987571954727, 0.06655726581811905, 0.2169434279203415 }),
+          3.0928874015808105,
           std::make_unique<Response<float, int> >(0),
           std::make_unique<Response<float, int> >(1)
           ),
         std::make_unique<Response<float, int> >(2)
-        ),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
+        ))
     );
-
 
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.9774257025571, -0.20095147055468665, 0.012604451134322587, -0.015914730117438724, -0.06201089936099892 }),
-        3.9924452660765164,
+        as_projector({ 0.9740977883338928, -0.19465802609920502, -0.022930234670639038, 0.08263365924358368, -0.07673182338476181 }),
+        4.049604415893555,
         std::make_unique<Condition<float, int> >(
-          as_projector({ 1.0, 2.0286166352810033e-15, -0.0, -0.0, -0.0 }),
-          1.5000000000000053,
+          as_projector({ 0.14019571244716644, 0.9772301912307739, 0.0012194644659757614, 0.025386467576026917, 0.157227024435997 }),
+          2.9420154094696045,
           std::make_unique<Response<float, int> >(0),
           std::make_unique<Response<float, int> >(1)
           ),
         std::make_unique<Response<float, int> >(2)
-        ),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
-
+        ))
     );
-
-
 
   ASSERT_EQ(expect, result);
   ASSERT_EQ(expect.seed, result.seed);
@@ -259,11 +246,11 @@ TEST(Forest, TrainLDASomeVariablesMultivariateThreeGroups) {
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.8978734016418457, 0.0, 0.0, 0.0, -0.4402538239955902 }),
-        4.231846332550049,
+        as_projector({ 0.9023475646972656, 0.0, 0.0, 0.4310089647769928, 0.0 }),
+        5.072210311889648,
         std::make_unique<Condition<float, int> >(
-          as_projector({ 0.0, 0.9940404891967773, 0.0, 0.0, 0.10901174694299698 }),
-          2.638364315032959,
+          as_projector({ 0.0, 0.9889134764671326, 0.0, 0.14849309623241425, 0.0 }),
+          2.7555019855499268,
           std::make_unique<Response<float, int> >(0),
           std::make_unique<Response<float, int> >(1)
           ),
@@ -275,11 +262,11 @@ TEST(Forest, TrainLDASomeVariablesMultivariateThreeGroups) {
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.8959224820137024, 0.0, 0.0, 0.0, -0.444210410118103 }),
-        4.226912021636963,
+        as_projector({ 0.9626245498657227, 0.0, 0.0, 0.0, -0.2708394229412079 }),
+        4.723257541656494,
         std::make_unique<Condition<float, int> >(
-          as_projector({ 0.0, 0.9587026238441467, 0.0, 0.0, 0.284410297870636 }),
-          2.798901319503784,
+          as_projector({ 0.0, 1.0, 0.0, 0.0, 0.0 }),
+          2.5,
           std::make_unique<Response<float, int> >(0),
           std::make_unique<Response<float, int> >(1)
           ),
@@ -291,12 +278,12 @@ TEST(Forest, TrainLDASomeVariablesMultivariateThreeGroups) {
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.0, 0.893912136554718, 0.0, 0.44824233651161194, 0.0 }),
-        3.207777976989746,
+        as_projector({ 0.0, 0.0, 0.43462103605270386, 0.0, 0.9006133675575256 }),
+        1.1528732776641846,
         std::make_unique<Response<float, int> >(0),
         std::make_unique<Condition<float, int> >(
-          as_projector({ 0.0, 1.0, 0.0, 0.0, 0.0 }),
-          6.5,
+          as_projector({ 0.0, 0.0, -0.9125092029571533, 0.0, 0.4090558588504791 }),
+          0.10619720071554184,
           std::make_unique<Response<float, int> >(1),
           std::make_unique<Response<float, int> >(2)
           ))
@@ -307,18 +294,17 @@ TEST(Forest, TrainLDASomeVariablesMultivariateThreeGroups) {
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.0, 0.9463106393814087, 0.32325872778892517, 0.0, 0.0 }),
-        3.200251340866089,
-        std::make_unique<Response<float, int> >(0),
+        as_projector({ -0.9543675780296326, 0.0, 0.2986343502998352, 0.0, 0.0 }),
+        -4.9326019287109375,
+        std::make_unique<Response<float, int> >(2),
         std::make_unique<Condition<float, int> >(
-          as_projector({ 0.0, 0.0, 0.3905499279499054, 0.0, 0.9205817580223083 }),
-          1.619154691696167,
-          std::make_unique<Response<float, int> >(2),
+          as_projector({ 0.0, 0.9989996552467346, 0.0, 0.04471937566995621, 0.0 }),
+          2.6413731575012207,
+          std::make_unique<Response<float, int> >(0),
           std::make_unique<Response<float, int> >(1)
           ))
       )
     );
-
 
   ASSERT_EQ(expect, result);
   ASSERT_EQ(seed, result.seed);
@@ -370,46 +356,47 @@ TEST(Forest, TrainPDAAllVariablesMultivariateTwoGroups) {
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.9655843123155974, 0.08681796476306242, 0.09953066811975722, -0.1290329926431043, -0.06476274943747946, -0.0647627494374795, -0.06476274943747948, -0.06476274943747948, -0.06476274943747941, -0.06476274943747942, -0.06476274943747944, -0.06476274943747942 }),
-        1.66054084868256,
-        std::make_unique<Response<float, int> >(0),
-        std::make_unique<Response<float, int> >(1)
-        ),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
-    );
-
-  expect.add_tree(
-    std::make_unique<BootstrapTree<float, int> >(
-      std::make_unique<Condition<float, int> >(
         as_projector({ 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }),
         2.5,
         std::make_unique<Response<float, int> >(0),
-        std::make_unique<Response<float, int> >(1)),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
+        std::make_unique<Response<float, int> >(1)
+        ))
     );
 
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.9607071714826417, 0.13071424952758612, 0.18649074813826336, -0.06675108245672948, -0.05089328231941315, -0.05089328231941322, -0.05089328231941318, -0.05089328231941322, -0.05089328231941308, -0.050893282319413084, -0.05089328231941308, -0.0508932823194131 }),
-        1.9601144528047953,
+        as_projector({ 0.9404149055480957, 0.1384861171245575, 0.27520284056663513, -0.028697863221168518,
+                       -0.04985111951828003, -0.04985113441944122, -0.04985114187002182, -0.04985113441944122,
+                       -0.04985114559531212, -0.049851153045892715, -0.04985114559531212, -0.04985113441944122 }),
+        2.056182384490967,
         std::make_unique<Response<float, int> >(0),
-        std::make_unique<Response<float, int> >(1)),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
+        std::make_unique<Response<float, int> >(1)
+        ))
     );
 
   expect.add_tree(
     std::make_unique<BootstrapTree<float, int> >(
       std::make_unique<Condition<float, int> >(
-        as_projector({ 0.9611377266908191, 0.027169137836983416, 0.08147067425776834, -0.05364933895611067, -0.09080224800793527, -0.0908022480079353, -0.0908022480079353, -0.09080224800793528, -0.09080224800793517, -0.09080224800793522, -0.09080224800793522, -0.09080224800793524 }),
-        1.3347158081570496,
+        as_projector({ 0.9504902362823486, -0.032086681574583054, -0.0, -0.0015316768549382687,
+                       -0.10927978157997131, -0.10927978903055191, -0.10927974432706833, -0.10927967727184296,
+                       -0.10927972197532654, -0.10927971452474594, -0.10927971452474594, -0.10927971452474594 }),
+        1.0509742498397827,
         std::make_unique<Response<float, int> >(0),
-        std::make_unique<Response<float, int> >(1)),
-      TrainingSpec<float, int>::uniform_glda(n_vars, lambda),
-      std::make_shared<BootstrapDataSpec<float, int> >(data, groups, std::set<int>({ 0, 1, 2 }), std::vector<int>({ 0, 1 })))
+        std::make_unique<Response<float, int> >(1)
+        ))
+    );
+
+  expect.add_tree(
+    std::make_unique<BootstrapTree<float, int> >(
+      std::make_unique<Condition<float, int> >(
+        as_projector({ 1.0, -1.4527107339290524e-07, -2.9038861271146743e-07, -9.766825570522997e-08,
+                       8.5481985934166e-08, 8.548196461788393e-08, 8.54819361961745e-08, 8.54819361961745e-08,
+                       8.54819361961745e-08, 8.54819361961745e-08, 8.54819361961745e-08, 8.54819361961745e-08 }),
+        2.5,
+        std::make_unique<Response<float, int> >(0),
+        std::make_unique<Response<float, int> >(1)
+        ))
     );
 
   ASSERT_EQ(expect, result);
@@ -701,11 +688,11 @@ TEST(Forest, VariableImportanceProjectorLDASomeVariablesMultivariateThreeGroups)
 
   DVector<float> expected(5);
   expected <<
-    0.2082739,
-    0.0830787,
-    0.2489474,
-    0.3571811,
-    0.1128317;
+    0.291208,
+    0.374995,
+    0.047913,
+    0.096193,
+    0.073253;
 
   ASSERT_APPROX(expected, result);
 }
@@ -750,18 +737,18 @@ TEST(Forest, VariableImportanceProjectorPDAAllVariablesMultivariateTwoGroups) {
   DVector<float> result = forest.variable_importance(VIProjectorStrategy<float, int>());
 
   Projector<float> expected = as_projector({
-    0.497305,
-    0.00889968,
-    0.0137289,
-    0.0177429,
-    0.0126566,
-    0.0126566,
-    0.0126566,
-    0.0126566,
-    0.0126566,
-    0.0126566,
-    0.0126566,
-    0.0126566 });
+    0.4973304271697998,
+    0.0065120994113385,
+    0.0112658599391579,
+    0.0023133084177970,
+    0.0105210691690444,
+    0.0105212237685918,
+    0.0105212181806564,
+    0.0105212191119790,
+    0.0105212163180112,
+    0.0105212163180112,
+    0.0105212200433015,
+    0.0105212181806564 });
 
   ASSERT_APPROX(expected, result);
 }
@@ -848,11 +835,11 @@ TEST(Forest, VariableImportanceProjectorAdjustedLDASomeVariablesMultivariateThre
 
   DVector<float> expected(5);
   expected <<
-    0.155350,
-    0.078865,
-    0.027610,
-    0.032386,
-    0.015119;
+    0.31015947461128235,
+    0.33594012260437012,
+    0.01743866316974163,
+    0.04736451059579849,
+    0.02686723135411739;
 
 
   ASSERT_APPROX(expected, result);
@@ -899,18 +886,18 @@ TEST(Forest, VariableImportanceProjectorAdjustedPDAAllVariablesMultivariateTwoGr
 
   DVector<float> expected(12);
   expected <<
-    0.983637,
-    0.018022,
-    0.028957,
-    0.036786,
-    0.026617,
-    0.026617,
-    0.026617,
-    0.026617,
-    0.026617,
-    0.026617,
-    0.026617,
-    0.026617;
+    0.98541688919067383,
+    0.01270248740911483,
+    0.02189479023218154,
+    0.00450026756152510,
+    0.02072355896234512,
+    0.02072386071085929,
+    0.02072384767234325,
+    0.02072384953498840,
+    0.02072384580969810,
+    0.02072384394705295,
+    0.02072385139763355,
+    0.02072384953498840;
 
   ASSERT_APPROX(expected, result);
 }
@@ -999,11 +986,11 @@ TEST(Forest, VariableImportancePermutationLDASomeVariablesMultivariateThreeGroup
 
   DVector<float> expected(5);
   expected <<
-    0.07499,
-    0.18181,
-    0.00000,
-    0.04166,
-    0.02462;
+    0.07083333283662796,
+    0.22499999403953552,
+    -0.0041666701436042786,
+    0,
+    0.024999991059303284;
 
 
   ASSERT_APPROX(expected, result);
@@ -1052,7 +1039,7 @@ TEST(Forest, VariableImportancePermutationPDAAllVariablesMultivariateTwoGroups) 
 
   DVector<float> expected(12);
   expected <<
-    0.0,
+    0.22499999403953552,
     0.0,
     0.0,
     0.0,
@@ -2115,9 +2102,9 @@ TEST(Forest, ConfusionMatrix) {
 
   Data<int> expected(3, 3);
   expected <<
-    9, 0, 0,
-    0, 10, 0,
-    0, 0, 6;
+    7, 0, 0,
+    0, 8, 0,
+    0, 0, 7;
 
   ASSERT_EQ(expected.size(), result.values.size());
   ASSERT_EQ(expected.rows(), result.values.rows());

--- a/core/src/Normal.hpp
+++ b/core/src/Normal.hpp
@@ -16,7 +16,7 @@ namespace models::stats {
 
       double gen_unif01() {
         static constexpr uint64_t PRECISION = 53;
-        static constexpr uint64_t MAX_BITS = (1ULL << PRECISION) - 1;
+        static constexpr uint64_t MAX_BITS  = (1ULL << PRECISION) - 1;
 
         uint64_t bits = 0;
 
@@ -64,7 +64,7 @@ namespace models::stats {
         double z;
 
         if (!cached_z.has_value()) {
-          double r = std::sqrt(-2.0 * std::log(u1));
+          double r     = std::sqrt(-2.0 * std::log(u1));
           double theta = 2.0 * M_PI * u2;
 
           z = r * std::cos(theta);

--- a/core/src/Normal.hpp
+++ b/core/src/Normal.hpp
@@ -3,27 +3,85 @@
 #include "Random.hpp"
 #include "Uniform.hpp"
 
+#include <optional>
+
+
 namespace models::stats {
   class Normal {
     private:
       float mean;
       float std_dev;
-      mutable Uniform unif{ 0, 1 };
+
+      std::optional<float> cached_z;
+
+      double gen_unif01() {
+        static constexpr uint64_t PRECISION = 53;
+        static constexpr uint64_t MAX_BITS = (1ULL << PRECISION) - 1;
+
+        uint64_t bits = 0;
+
+        while (bits == 0 || bits == MAX_BITS) {
+          uint64_t x = Random::gen();
+          uint64_t y = Random::gen();
+          bits = ((x << 21) | (y >> 11)) & MAX_BITS;
+        }
+
+        return static_cast<double>(bits) / static_cast<double>(MAX_BITS + 1);
+      }
+
+      float denormalize(float z) {
+        return mean + std_dev * z;
+      }
 
     public:
       Normal(float mean, float std_dev) : mean(mean), std_dev(std_dev) {
       }
 
-      float operator()() const {
-        float u1 = unif();
-        float u2 = unif();
+      /**
+       * @brief Generates a normally distributed random number using the Box-Muller transform.
+       *
+       * This implementation uses the polar form of the Box-Muller transform to convert
+       * uniform random variables into normally distributed ones. The algorithm works by
+       * generating pairs of independent standard normal random variables (Z1, Z2) using:
+       *
+       * Z1 = R * cos(θ)
+       * Z2 = R * sin(θ)
+       *
+       * where:
+       * - R = sqrt(-2 * ln(U1))  [radius]
+       * - θ = 2π * U2            [angle]
+       * - U1, U2 are uniform random variables in (0,1)
+       *
+       * For efficiency, this implementation caches the second generated value (Z2)
+       * for the next call.
+       *
+       * @return A random float from the normal distribution with specified mean and standard deviation
+       */
+      float operator()() {
+        double u1 = gen_unif01();
+        double u2 = gen_unif01();
 
-        float z = std::sqrt(-2.0f * std::log(u1)) * std::cos(2.0f * M_PI * u2);
-        return mean + std_dev * z;
+        double z;
+
+        if (!cached_z.has_value()) {
+          double r = std::sqrt(-2.0 * std::log(u1));
+          double theta = 2.0 * M_PI * u2;
+
+          z = r * std::cos(theta);
+
+          double z2 = r * std::sin(theta);
+
+          cached_z = static_cast<float>(z2);
+        } else {
+          z = cached_z.value();
+        }
+
+        return denormalize(z);
       }
 
-      std::vector<float> operator()(int count) const {
+      std::vector<float> operator()(int count) {
         std::vector<float> result(count);
+
         for (int i = 0; i < count; i++) {
           result[i] = operator()();
         }

--- a/core/src/Random.cpp
+++ b/core/src/Random.cpp
@@ -1,20 +1,20 @@
 #include "Random.hpp"
 
 namespace models::stats::Random {
-  std::mt19937 rng{};
+  pcg32 rng{};
 
   uint_fast32_t min() {
-    return rng.min();
+    return 0;
   }
 
   void seed(const uint_fast32_t value) {
     #ifdef _OPENMP
     #pragma omp parallel
     {
-      rng.seed(value + omp_get_thread_num());
+      rng.seed(value, static_cast<uint64_t>(omp_get_thread_num()));
     }
     #else
-    rng.seed(value);
+    rng.seed(value, 0u);
     #endif
   }
 

--- a/core/src/Random.hpp
+++ b/core/src/Random.hpp
@@ -1,12 +1,13 @@
 #pragma once
 #include <random>
+#include <pcg_random.hpp>
 
 #ifdef _OPENMP
 #include "omp.h"
 #endif
 
 namespace models::stats::Random {
-  extern std::mt19937 rng;
+  extern pcg32 rng;
   #pragma omp threadprivate(rng)
 
   uint_fast32_t min();

--- a/core/src/Uniform.hpp
+++ b/core/src/Uniform.hpp
@@ -2,20 +2,52 @@
 
 #include <random>
 #include "Random.hpp"
+
 namespace models::stats {
   class Uniform {
     private:
       int min;
       int max;
 
+      /**
+       * @brief Generates an unbiased random integer in range [0, s-1] using Lemire's method
+       *
+       * Implementation of Daniel Lemire's fast and unbiased algorithm for random integers
+       * in an interval, as described in "Fast Random Integer Generation in an Interval"
+       * (ACM TOMS, 2019).
+       *
+       * The algorithm uses multiplication and bit shifts instead of division or modulo
+       * for better performance. It employs rejection sampling when necessary to ensure
+       * unbiased results.
+       *
+       * @param s The exclusive upper bound for the generated numbers (must be > 0)
+       * @return A uniformly distributed random integer in [0, s-1]
+       * @see https://arxiv.org/abs/1805.10941
+       */
+      int gen_lemire(uint32_t s) const {
+        uint32_t x = Random::gen();
+        uint64_t m = static_cast<uint64_t>(x) * s;
+        uint32_t l = static_cast<uint32_t>(m);
+
+        if (l < s) {
+          uint32_t t = -s % s;
+
+          while (l < t) {
+            x = Random::gen();
+            m = static_cast<uint64_t>(x) * s;
+            l = static_cast<uint32_t>(m);
+          }
+        }
+
+        return m >> 32;
+      }
+
     public:
       Uniform(int min, int max) : min(min), max(max) {
       }
 
       int operator()() const {
-        uint64_t range         = static_cast<uint64_t>(max) - min + 1;
-        uint64_t random_number = Random::gen() - Random::min();
-        return min + static_cast<int>(random_number % range);
+        return min + gen_lemire(max + 1 - min);
       }
 
       std::vector<int> operator()(int count) const {

--- a/core/src/Uniform.hpp
+++ b/core/src/Uniform.hpp
@@ -60,6 +60,18 @@ namespace models::stats {
         return result;
       }
 
+      /**
+       * @brief Generates a vector of distinct random integers from the uniform distribution
+       *
+       * This method implements the Fisher-Yates (Knuth) shuffle algorithm to generate
+       * a specified number of unique random integers from the defined range [min, max].
+       * The resulting integers are uniformly distributed and guaranteed to be unique.
+       *
+       * @param count The number of distinct integers to generate
+       * @return A vector containing count distinct integers from the range [min, max]
+       * @throws std::invalid_argument if count exceeds the number of possible unique values
+       *         in the range [min, max]
+       */
       std::vector<int> distinct(int count) {
         int range_size = max - min + 1;
 
@@ -70,8 +82,8 @@ namespace models::stats {
         std::vector<int> values(range_size);
         std::iota(values.begin(), values.end(), min);
 
-        for (int i = range_size - 1; i > 0; i--) {
-          int j = operator()() % (i + 1);
+        for (int i = range_size - 1; i >= 0; i--) {
+          int j = gen_lemire(i + 1);
           std::swap(values[i], values[j]);
         }
 

--- a/core/src/VIStrategy.test.cpp
+++ b/core/src/VIStrategy.test.cpp
@@ -363,11 +363,11 @@ TEST(VIProjectorStrategy, ForestLDASomeVariablesMultivariateThreeGroups) {
 
   DVector<float> expected(5);
   expected <<
-    0.2082739,
-    0.0830787,
-    0.2489474,
-    0.3571811,
-    0.1128317;
+    0.29120835661888123,
+    0.37499451637268066,
+    0.04791311174631118,
+    0.09619309753179550,
+    0.07325347512960434;
 
   ASSERT_APPROX(expected, result);
 }
@@ -413,18 +413,18 @@ TEST(VIProjectorStrategy, ForestPDAAllVariablesMultivariateTwoGroups) {
 
   DVector<float> expected(12);
   expected <<
-    0.49693089723587036,
-    0.00916083808988332,
-    0.01470966450870037,
-    0.01864582672715187,
-    0.01347902603447437,
-    0.01347890309989452,
-    0.01347890309989452,
-    0.01347890403121709,
-    0.01347837783396244,
-    0.01347837783396244,
-    0.01347837597131729,
-    0.01347837410867214;
+    0.4973304271697998,
+    0.0065120994113385,
+    0.0112658599391579,
+    0.0023133084177970,
+    0.0105210691690444,
+    0.0105212237685918,
+    0.0105212181806564,
+    0.0105212191119790,
+    0.0105212163180112,
+    0.0105212163180112,
+    0.0105212200433015,
+    0.0105212181806564;
 
   ASSERT_APPROX(expected, result);
 }
@@ -761,11 +761,11 @@ TEST(VIProjectorAdjustedStrategy, ForestLDASomeVariablesMultivariateThreeGroups)
 
   DVector<float> expected(5);
   expected <<
-    0.155350,
-    0.078865,
-    0.027610,
-    0.032386,
-    0.015119;
+    0.31015947461128235,
+    0.33594012260437012,
+    0.01743866316974163,
+    0.04736451059579849,
+    0.02686723135411739;
 
 
   ASSERT_APPROX(expected, result);
@@ -812,18 +812,18 @@ TEST(VIProjectorAdjustedStrategy, ForestPDAAllVariablesMultivariateTwoGroups) {
 
   DVector<float> expected(12);
   expected <<
-    0.98363780975341797,
-    0.01802294887602329,
-    0.02895770967006683,
-    0.03678614646196365,
-    0.02661818079650402,
-    0.02661794051527977,
-    0.02661794051527977,
-    0.02661794051527977,
-    0.02661690860986709,
-    0.02661690860986709,
-    0.02661690488457679,
-    0.02661690115928649;
+    0.98541688919067383,
+    0.01270248740911483,
+    0.02189479023218154,
+    0.00450026756152510,
+    0.02072355896234512,
+    0.02072386071085929,
+    0.02072384767234325,
+    0.02072384953498840,
+    0.02072384580969810,
+    0.02072384394705295,
+    0.02072385139763355,
+    0.02072384953498840;
 
   ASSERT_APPROX(expected, result);
 }
@@ -1019,8 +1019,8 @@ TEST(VIPermutationStrategy, BootstrapTreeLDAMultivariateThreeGroups) {
 
   DataColumn<float> expected(5);
   expected <<
-    0.33333,
     0.44444,
+    0.27777,
     0.00000,
     0.00000,
     0.00000;
@@ -1164,11 +1164,11 @@ TEST(VIPermutationStrategy, ForestLDASomeVariablesMultivariateThreeGroups) {
 
   DVector<float> expected(5);
   expected <<
-    0.07499,
-    0.18181,
-    0.00000,
-    0.04166,
-    0.02462;
+    0.07083333283662796,
+    0.22499999403953552,
+    -0.0041666701436042786,
+    0,
+    0.024999991059303284;
 
   ASSERT_APPROX(expected, result);
 }
@@ -1214,7 +1214,7 @@ TEST(VIPermutationStrategy, ForestPDAAllVariablesMultivariateTwoGroups) {
 
   DVector<float> expected(12);
   expected <<
-    0.0,
+    0.22499999403953552,
     0.0,
     0.0,
     0.0,


### PR DESCRIPTION
Fixes module bias in `Uniform` class, present both in the single number generation and in the Fisher-Yates implementation. Bases the new implementation in [Lemire's algorithm.](https://arxiv.org/abs/1805.10941). Tweaks Box-Muller transform implementation so it's a bit more efficient.

Switches `std::mt19937` to [PCG](https://www.pcg-random.org/), as the former is not suitable for parallel computing.