### PR TITLE
Report per-class error rates in R confusion matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+- CLI: a class with no observations in the data is rendered as `-` in the confusion matrix's error column instead of `nan%`. This happens when the model predicts a class that never appears as an actual label, for example when predicting on a subset of the data.
+
 - CLI: `predict` now maps data-file labels through the model's training labels and keeps predictions in input row order. Previously the rows were re-sorted by label and label codes were compared by file position, so a data file listing classes in a different order than the training file reported inverted metrics and misaligned saved predictions. A label absent from training is now an error.
 - CLI: `summarize --data` had the same label-space problem when recomputing metrics for a model saved with `--no-metrics`. It now maps labels through the model's training labels, validates the feature count of the data against the model, and reproduces the training row order so the recomputed out-of-bag metrics line up with the stored bootstrap sample indices.
 - CLI: `train` and `evaluate` honor `--mode` when parsing the CSV — a regression response written as integers stays numeric instead of being label-encoded (previously the model silently trained on label codes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ppforest2 0.1.3
 
+## New features
+
+- R: `summary()` on a classification tree or forest now reports a per-class error rate alongside each confusion matrix, and prints the overall error rate above the matrix rather than below it. The headings, the quantities, and their precision now match the output of the `summarize` command, so an R summary and a command-line summary of the same model report the same numbers in the same order.
+
 ## Bug fixes
 
 - CLI: a class with no observations in the data is rendered as `-` in the confusion matrix's error column instead of `nan%`. This happens when the model predicts a class that never appears as an actual label, for example when predicting on a subset of the data.

--- a/bindings/R/R/pprf.R
+++ b/bindings/R/R/pprf.R
@@ -363,10 +363,8 @@ summary.pprf_classification <- function(object, ...) {
   NextMethod()
   model <- object
 
-  cat("Training Confusion Matrix:\n\n")
   print_confusion_matrix(ppforest2_predict_forest(model, model$x), model)
   cat("\n")
-  cat("OOB Confusion Matrix:\n\n")
   print_oob_confusion_matrix(model)
   cat("\n")
 

--- a/bindings/R/R/pptr.R
+++ b/bindings/R/R/pptr.R
@@ -296,7 +296,6 @@ summary.pptr_classification <- function(object, ...) {
   NextMethod()
   model <- object
 
-  cat("Confusion Matrix:\n\n")
   print_confusion_matrix(ppforest2_predict_tree(model, model$x), model)
   cat("\n")
 

--- a/bindings/R/R/util.R
+++ b/bindings/R/R/util.R
@@ -139,30 +139,59 @@ print_training_spec <- function(spec) {
   cat("\n")
 }
 
-print_confusion_matrix <- function(raw_preds, model) {
+# A rate of `NA` means there was nothing to compute it from (an empty matrix,
+# or a class with no observations). The CLI renders that case as "-" too.
+format_error_rate <- function(rate, digits) {
+  if (is.na(rate)) "-" else sprintf(paste0("%.", digits, "f%%"), rate * 100)
+}
+
+# Classification metrics reporting mirrors the C++ presentation layer
+# (`print_metrics_block` in `io/Presentation.cpp`): the overall error rate on
+# its own line, then the confusion matrix carrying a per-class error column.
+# The quantities, their order, and their precision match, so an R summary and
+# a CLI summary of the same model read the same. Changing one side means
+# changing the other.
+#
+# `label` prefixes both headings ("Training", "OOB"); an empty label yields
+# the bare "Error:" / "Confusion Matrix:" headings.
+print_metrics_block <- function(preds, actual, label) {
+  counts <- unclass(table(Actual = actual, Predicted = preds))
+  titled <- function(heading) if (nzchar(label)) paste(label, heading) else heading
+
+  total <- sum(counts)
+  overall_error <- if (total > 0) 1 - sum(diag(counts)) / total else NA_real_
+
+  cat(titled("Error:"), " ", format_error_rate(overall_error, 2), "\n", sep = "")
+  cat(titled("Confusion Matrix:"), "\n\n", sep = "")
+
+  # Rows are actual classes, so the per-row rate is the share of a class's
+  # observations that were predicted as something else.
+  row_totals  <- rowSums(counts)
+  group_error <- ifelse(row_totals > 0, 1 - diag(counts) / row_totals, NA_real_)
+
+  display <- cbind(
+    format(counts),
+    Error = vapply(group_error, format_error_rate, character(1), digits = 1))
+  names(dimnames(display)) <- names(dimnames(counts))
+
+  print(display, quote = FALSE, right = TRUE)
+}
+
+print_confusion_matrix <- function(raw_preds, model, label = "Training") {
   preds <- factor(model$groups[raw_preds], levels = model$groups)
   actual <- factor(model$groups[model$y], levels = model$groups)
-  cm <- table(Actual = actual, Predicted = preds)
-  print(cm)
-  cat("\n")
-  n <- length(actual)
-  correct <- sum(preds == actual)
-  cat("Training error: ", round((1 - correct / n) * 100, 2), "%\n", sep = "")
+  print_metrics_block(preds, actual, label)
 }
 
 print_oob_confusion_matrix <- function(model) {
   # `oob_predictions()` is the lazy accessor; returns a factor with `NA` for
-  # observations with no OOB tree.
+  # observations with no OOB tree. Those rows carry no OOB information, so
+  # they are excluded from the matrix — as they are in the C++ OOB metrics.
   oob_preds <- oob_predictions(model)
   oob_mask  <- !is.na(oob_preds)
   preds     <- oob_preds[oob_mask]
   actual    <- factor(model$groups[model$y[oob_mask]], levels = model$groups)
-  cm <- table(Actual = actual, Predicted = preds)
-  print(cm)
-  cat("\n")
-  n <- length(actual)
-  correct <- sum(as.character(preds) == as.character(actual))
-  cat("OOB error: ", round((1 - correct / n) * 100, 2), "%\n", sep = "")
+  print_metrics_block(preds, actual, "OOB")
 }
 
 process_predict_arguments <- function(object, new_data, ...) {

--- a/bindings/R/tests/testthat/test-pprf.R
+++ b/bindings/R/tests/testthat/test-pprf.R
@@ -444,6 +444,71 @@ describe("pprf edge cases", {
   })
 })
 
+describe("pprf classification summary metrics", {
+  model <- pprf(Species ~ ., data = iris, size = 5, seed = 0, threads = 1)
+  out <- capture.output(summary(model))
+
+  # Row for a class in a printed confusion matrix, e.g.
+  #   "  setosa         50          0         0  0.0%"
+  class_row <- function(lines, label) {
+    row <- grep(paste0("^\\s+", label, "\\s"), lines, value = TRUE)
+    expect_length(row, 2L)  # training matrix and OOB matrix
+    row
+  }
+
+  it("prints the overall error above each confusion matrix", {
+    training_error <- grep("^Training Error:", out)
+    training_cm <- grep("^Training Confusion Matrix:", out)
+    oob_error_line <- grep("^OOB Error:", out)
+    oob_cm <- grep("^OOB Confusion Matrix:", out)
+
+    expect_length(training_error, 1L)
+    expect_length(oob_error_line, 1L)
+    expect_lt(training_error, training_cm)
+    expect_lt(oob_error_line, oob_cm)
+  })
+
+  it("reports the overall error as a percentage with two decimals", {
+    expect_match(grep("^Training Error:", out, value = TRUE), "^Training Error: [0-9]+\\.[0-9]{2}%$")
+    expect_match(grep("^OOB Error:", out, value = TRUE), "^OOB Error: [0-9]+\\.[0-9]{2}%$")
+  })
+
+  it("adds a per-class error column to both confusion matrices", {
+    headers <- grep("^Actual\\s", out, value = TRUE)
+    expect_length(headers, 2L)
+    expect_true(all(endsWith(headers, "Error")))
+
+    for (label in levels(iris$Species)) {
+      rows <- class_row(out, label)
+      expect_true(all(grepl("[0-9]+\\.[0-9]%$", rows)), info = label)
+    }
+  })
+
+  it("per-class error matches the counts printed on the same row", {
+    row <- class_row(out, "setosa")[1]
+    fields <- strsplit(trimws(row), "\\s+")[[1]]
+    counts <- as.integer(fields[2:4])
+    printed <- fields[5]
+
+    expected <- sprintf("%.1f%%", (1 - counts[1] / sum(counts)) * 100)
+    expect_equal(printed, expected)
+  })
+
+  it("renders a class with no observations as a dash", {
+    # A class the model never sees in `actual` has no error rate to report;
+    # the CLI prints "-" for that row as well.
+    lvls <- c("a", "b", "c")
+    actual <- factor(c("a", "a", "b"), levels = lvls)
+    preds <- factor(c("a", "b", "b"), levels = lvls)
+
+    rendered <- capture.output(ppforest2:::print_metrics_block(preds, actual, "Training"))
+    row <- grep("^\\s+c\\s", rendered, value = TRUE)
+
+    expect_length(row, 1L)
+    expect_true(endsWith(trimws(row), "-"))
+  })
+})
+
 describe("pprf regression", {
   it("end-to-end on mtcars (formula + predict + summary)", {
     # Real-dataset round-trip counterpart to the simulated-data tests

--- a/bindings/R/tests/testthat/test-pptr.R
+++ b/bindings/R/tests/testthat/test-pptr.R
@@ -374,6 +374,25 @@ describe("pptr edge cases", {
   })
 })
 
+describe("pptr classification summary metrics", {
+  it("labels the single-tree metrics block the way the CLI does", {
+    model <- pptr(Species ~ ., data = iris, seed = 0)
+    out <- capture.output(summary(model))
+
+    # The CLI titles a tree's training metrics "Training Error:" /
+    # "Training Confusion Matrix:", same as a forest's.
+    expect_match(grep("^Training Error:", out, value = TRUE), "^Training Error: [0-9]+\\.[0-9]{2}%$")
+    expect_length(grep("^Training Confusion Matrix:", out), 1L)
+
+    # A tree has no OOB sample, so no OOB block.
+    expect_length(grep("^OOB", out), 0L)
+
+    header <- grep("^Actual\\s", out, value = TRUE)
+    expect_length(header, 1L)
+    expect_true(endsWith(header, "Error"))
+  })
+})
+
 describe("pptr regression", {
   it("end-to-end on mtcars (formula + predict + summary)", {
     # Real-dataset round-trip counterpart to the simulated-data tests

--- a/bindings/R/tests/testthat/test-reproducibility.R
+++ b/bindings/R/tests/testthat/test-reproducibility.R
@@ -169,6 +169,35 @@ compare_confusion_matrix <- function(model, golden, data, response) {
     tolerance = 1e-3)
 }
 
+# The C++ CLI renders `training_metrics` straight from the golden values, so
+# asserting the printed R summary against the same numbers keeps the two
+# presentations reporting identical information. Formats mirror the CLI:
+# overall error at two decimals, per-class error at one.
+compare_printed_metrics <- function(model, golden) {
+  out <- capture.output(summary(model))
+  expected_cm <- golden$training_metrics$confusion_matrix
+
+  labels <- as.character(as_vec(expected_cm$labels))
+  group_errors <- as.numeric(as_vec(expected_cm$group_errors))
+
+  overall <- sprintf("%.2f%%", as.numeric(golden$training_metrics$error_rate) * 100)
+  expect_true(any(grepl(paste0("Training Error: ", overall), out, fixed = TRUE)),
+    info = paste("expected overall training error", overall))
+
+  # A forest prints an OOB matrix as well, and `training_metrics` describes
+  # the training one — read the rows under the first matrix header only.
+  header <- grep("^Actual\\s", out)[1]
+  expect_false(is.na(header))
+  rows <- out[header + seq_along(labels)]
+
+  for (i in seq_along(labels)) {
+    row <- rows[grepl(paste0("^\\s+", labels[i], "\\s"), rows)]
+    expect_length(row, 1L)
+    expect_true(endsWith(trimws(row), sprintf("%.1f%%", group_errors[i] * 100)),
+      info = paste("class", labels[i], "error column"))
+  }
+}
+
 compare_vote_proportions <- function(model, golden, data) {
   probs <- predict(model, data, type = "prob")
   actual <- unname(as.matrix(probs))
@@ -287,6 +316,10 @@ describe("Reproducibility: iris forest-pda-n5-s0", {
     compare_confusion_matrix(model, golden, d, d$Species)
   })
 
+  it("printed summary metrics match golden file", {
+    compare_printed_metrics(model, golden)
+  })
+
   it("OOB error matches golden file", {
     expect_equal(oob_error(model), golden$oob_metrics$error_rate, tolerance = 1e-3)
   })
@@ -338,6 +371,10 @@ describe("Reproducibility: iris forest-pda-l05-n5-s0", {
 
   it("confusion matrix matches golden file", {
     compare_confusion_matrix(model, golden, d, d$Species)
+  })
+
+  it("printed summary metrics match golden file", {
+    compare_printed_metrics(model, golden)
   })
 
   it("OOB error matches golden file", {

--- a/bindings/R/tests/testthat/test-variable-importance.R
+++ b/bindings/R/tests/testthat/test-variable-importance.R
@@ -115,7 +115,7 @@ describe("pprf variable importance", {
     out <- capture.output(summary(model))
     expect_true(any(grepl("Variable Importance", out)))
     if (!is.na(oob_error(model))) {
-      expect_true(any(grepl("OOB error", out)))
+      expect_true(any(grepl("OOB Error:", out, fixed = TRUE)))
     }
   })
 })

--- a/core/src/cli/Predict.integration.test.cpp
+++ b/core/src/cli/Predict.integration.test.cpp
@@ -301,6 +301,30 @@ TEST(CLIPredictLabels, UnknownLabelFails) {
   EXPECT_NE(result.stderr_output.find("training labels"), std::string::npos);
 }
 
+/* A class the data never carries has no error rate to report, so its
+ * confusion-matrix row shows "-" rather than a division of zero by zero. */
+TEST(CLIPredictLabels, ClassWithNoObservationsShowsDash) {
+  TempFile train_csv(".csv");
+  write_file(train_csv.path(), SEPARABLE_TRAIN_CSV);
+
+  TempFile model;
+  model.clear();
+  auto train = run_ppforest2("-q train -d " + train_csv.path() + " -n 0 -r 0 -s " + model.path());
+  ASSERT_EQ(train.exit_code, 0);
+
+  // Every row is labelled "a" but sits in "b" territory, so "b" is predicted
+  // without ever appearing as an actual class.
+  TempFile predict_csv(".csv");
+  write_file(predict_csv.path(), "f1,f2,y\n11,5,a\n12,6,a\n13,5,a\n");
+
+  auto result = run_ppforest2("--no-color predict -M " + model.path() + " -d " + predict_csv.path());
+  ASSERT_EQ(result.exit_code, 0) << result.stderr_output;
+
+  // The "b" row is all zeros and must not render as a nan percentage.
+  EXPECT_EQ(result.stdout_output.find("nan"), std::string::npos) << result.stdout_output;
+  EXPECT_NE(result.stdout_output.find("  -"), std::string::npos) << result.stdout_output;
+}
+
 /* A data file whose feature count differs from the model's fails cleanly. */
 TEST(CLIPredictLabels, FeatureCountMismatchFails) {
   TempFile train_csv(".csv");

--- a/core/src/io/Presentation.cpp
+++ b/core/src/io/Presentation.cpp
@@ -249,7 +249,13 @@ namespace ppforest2::io {
         }
       }
 
-      row += fmt::format("  {:.1f}%", group_err[row_idx] * 100);
+      // A class with no observations has no error rate to report: its row
+      // sum is zero, so `group_errors()` divides 0 by 0. The R summaries
+      // render this case as "-" too.
+      int const row_total        = cm.values.row(row_idx).sum();
+      std::string const err_text = row_total > 0 ? fmt::format("{:.1f}%", group_err[row_idx] * 100) : std::string("-");
+
+      row += fmt::format("  {}", err_text);
       out.println("{}", row);
     }
 


### PR DESCRIPTION
R classification summaries reported less than the CLI did: the confusion matrix counts with a single overall error rate printed below them, against the CLI's overall rate above the matrix plus a per-class `Error` column. Reading the same model through the two interfaces gave different information.

## R summaries now mirror the CLI

```
Training Error: 4.00%
Training Confusion Matrix:

Actual       setosa versicolor virginica Error
  setosa         50          0         0  0.0%
  versicolor      0         47         3  6.0%
  virginica       0          3        47  6.0%
```

Same quantities, same order, same precision as `ppforest2 summarize` (two decimals overall, one per class), for both the training and OOB matrices. A shared `print_metrics_block` mirrors the C++ `print_metrics_block` in `io/Presentation.cpp`. R keeps its idiomatic `Actual` / `Predicted` dimnames.

Single trees are now titled "Training Error" / "Training Confusion Matrix", matching how the CLI titles a tree's metrics, instead of a bare "Confusion Matrix".

## A class with no observations no longer prints `nan%`

Adding the per-class column surfaced a CLI display bug. The rate divides a row's off-diagonal count by its row total, so a class with no observations computed 0/0 and printed `nan%`. It is reachable whenever the model predicts a class that never appears as an actual label, for example predicting on a subset of the data that omits a class. Both sides now print `-`. Committed separately since it stands on its own.

## Keeping the two presentations from drifting

The golden-file tests gain a check that the printed R summary carries the same error rates the golden `training_metrics` record. That is what the CLI renders from, so the two cannot diverge without a test failing.

Each commit carries its own changelog entry under the unreleased 0.1.3 section.